### PR TITLE
Update couch-peruser.rst

### DIFF
--- a/src/config/couch-peruser.rst
+++ b/src/config/couch-peruser.rst
@@ -44,3 +44,6 @@ couch_peruser Options
 
         [couch_peruser]
         delete_dbs = false
+        
+    Note: When using jwt authorization, the provided token must include a custom _couchdb.roles=['_admin'] claim to for
+    the peruser database to be properly created and accessible for the user provided in the sub= claim


### PR DESCRIPTION
Added information on couch_peruser in a jwt environment

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Addtl documentation information on how to make couch_peruser work with jwt authorization (need to include custom roles claim

## Testing recommendations

